### PR TITLE
fix(crawler): Try SoupParser for ValueError exceptions.

### DIFF
--- a/goose/__init__.py
+++ b/goose/__init__.py
@@ -62,7 +62,7 @@ class Goose(object):
         try:
             crawler = Crawler(self.config)
             article = crawler.crawl(crawl_candiate)
-        except UnicodeDecodeError, exception:
+        except (UnicodeDecodeError, ValueError), exception:
             if self.config.parser_class == 'soupparser':
                 raise exception
             else:


### PR DESCRIPTION
Couldn't reproduce in tests.
Exceptions:
- All strings must be XML compatible: Unicode or ASCII, no NULL bytes or control characters
- Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration.

Example URls:
- http://www.teenvogue.com/fashion/2014-10/chanel-party
- http://www.melconway.com/Home/Committees_Paper.html
