### PR TITLE
fix(extractor): Workaround some encoding errors.

### DIFF
--- a/goose/parsers.py
+++ b/goose/parsers.py
@@ -26,6 +26,7 @@ from lxml import etree
 from copy import deepcopy
 from goose.text import innerTrim
 from goose.text import encodeValue
+from BeautifulSoup import UnicodeDammit
 
 
 class Parser(object):
@@ -50,7 +51,7 @@ class Parser(object):
 
     @classmethod
     def fromstring(self, html):
-        html = encodeValue(html)
+        html = self.decode_html(html)
         self.doc = lxml.html.fromstring(html)
         return self.doc
 
@@ -233,6 +234,15 @@ class Parser(object):
             e0 = deepcopy(e0)
             e0.tail = None
         return self.nodeToString(e0)
+
+    @classmethod
+    def decode_html(self, html_string):
+        converted = UnicodeDammit(html_string, isHTML=True)
+        if not converted.unicode:
+            raise UnicodeDecodeError(
+                "Failed to detect encoding, tried [%s]",
+                ', '.join(converted.triedEncodings))
+        return converted.unicode
 
 
 class ParserSoup(Parser):


### PR DESCRIPTION
Use BeautifulSoup's UnicodeDammit to convert retrieved HTML.
That fixes some errors like:
- UnicodeDecodeError: 'utf8' codec can't decode byte 0xab in position 75: invalid start byte
- ValueError: All strings must be XML compatible: Unicode or ASCII, no NULL bytes or control characters
  Example with error http://www.teenvogue.com/fashion/2014-10/chanel-party.
